### PR TITLE
Install SBT on self-hosted gha runners

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ runs:
       id: cache-paths
       shell: bash
       run: |
-        echo "setupsbt_path=$HOME/work/_setupsbt" >> $GITHUB_OUTPUT
+        echo "setupsbt_path=$RUNNER_TEMP/_setupsbt" >> $GITHUB_OUTPUT
 
     - name: Cache sbt distribution
       id: cache-dir


### PR DESCRIPTION
The `$HOME/work` directory may not always exist on runners if they are self hosted for instance (our work folder was `$HOME/_work`).  

Github has a `$RUNNER_TEMP` location though that gets cleaned up between jobs and will exist.  

Instead of using a location like `$HOME/work` that might not exist we can use `$RUNNER_TEMP` that will.