### PR TITLE
Add build.properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.bsp/
+target/

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.10.3


### PR DESCRIPTION
so Scala Steward can pick up the sbt version and update it in the `action.yml`

See: https://github.com/VirtusLab/scala-steward-repos/pull/469
Alternative for: #13 