### PR TITLE
Pin actions/cache to v4.3.0 in sbt cache step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
     - name: Cache sbt distribution
       id: cache-dir
       if: steps.cache-tool-dir.outputs.cache-hit != 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ${{ steps.cache-paths.outputs.sbt_toolpath }}
         key: ${{ steps.cache-paths.outputs.sbt_cachekey }}


### PR DESCRIPTION
- pin the sbt distribution cache step to actions/cache@0057852 (v4.3.0) 
- ensure orgs with GitHub’s “Enforce SHA pinning” setting enabled can still consume this workflow 
