### PR TITLE
Add signature verification in monitoring mode

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,8 @@ runs:
    
     - name: "Verify the sbt distribution signature"
       id: "ampel-verify"
-      if: steps.cache-tool-dir.outputs.cache-hit != 'true' && steps.cache-dir.outputs.cache-hit != 'true'
+      # Skip on Windows/macOS until go-billy path fix lands: https://github.com/go-git/go-billy/issues/194
+      if: runner.os == 'Linux' && steps.cache-tool-dir.outputs.cache-hit != 'true' && steps.cache-dir.outputs.cache-hit != 'true'
       env:
         SBT_RUNNER_VERSION: ${{ inputs.sbt-runner-version }}
         SBT_DOWNLOADPATH: "${{ steps.cache-paths.outputs.sbt_downloadpath }}"


### PR DESCRIPTION
This is the first PR on the plan to make the installer artifacts verifiable. 

This PR adds another curl call to download the signature along with the sbt distribution and injects another step in the installer that verifies the signature with an off the shelf policy. We also temporarily embed the public key in the workflow to verify the binary, ideally we'll write a policy for the installer and keep it in another location.

To monitor things, the verification step is in monitoring mode for now, it will not fail the installation if the signature fails. We will enforce it once we observe it for a few days.