### PR TITLE
fix: Fixes Windows path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ runs:
         if [[ "$RUNNER_OS" == "Windows" ]]; then
           echo "sbt_toolpath=$RUNNER_TOOL_CACHE\\sbt\\$SBT_RUNNER_VERSION" >> "$GITHUB_OUTPUT"
           echo "sbt_downloadpath=$RUNNER_TEMP\\_sbt" >> "$GITHUB_OUTPUT"
-          echo "sbt_diskcache=$HOME\\AppData\\Local\\sbt" >> "$GITHUB_OUTPUT"
+          echo "sbt_diskcache=$LOCALAPPDATA\\sbt" >> "$GITHUB_OUTPUT"
         elif [[ "$RUNNER_OS" == "macOS" ]]; then
           echo "sbt_toolpath=$RUNNER_TOOL_CACHE/sbt/$SBT_RUNNER_VERSION" >> "$GITHUB_OUTPUT"
           echo "sbt_downloadpath=$RUNNER_TEMP/_sbt" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Fixes https://github.com/sbt/setup-sbt/issues/89

### Test

```bash
Post job cleanup.
Post job cleanup.
Cache hit occurred on the primary key Windows-sbt-diskcache-1.1.6, not saving cache.
Post job cleanup.
Cache hit occurred on the primary key Windows-sbt-1.12.11-1.1.6, not saving cache.
```
