### PR TITLE
fix: Fixes cache key

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ runs:
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ steps.cache-paths.outputs.sbt_diskcache }}
-        key: ${{ steps.cache-paths.outputs.sbt_diskcachekey }}
+        key: ${{ steps.cache-paths.outputs.sbt_diskcachekey }}-${{ hashFiles('**/*.scala', '**/*.sbt', '**/*.properties') }}
     - name: "Download and Install sbt"
       shell: bash
       env:


### PR DESCRIPTION
Fixes https://github.com/sbt/setup-sbt/issues/88

## Test

```bash
Post job cleanup.
Post job cleanup.
/usr/bin/tar --posix -cf cache.tzst --exclude cache.tzst -P -C /home/runner/work/setup-sbt/setup-sbt --files-from manifest.txt --use-compress-program zstdmt
Sent 45699 of 45699 (100.0%), 0.6 MBs/sec
Cache saved with key: Linux-sbt-diskcache-1.1.6-50527be04f46bb26dc657c974c1d2dbfddebbccd296d8add0a0aedad683f20ce
Post job cleanup.
Cache hit occurred on the primary key Linux-sbt-1.12.11-1.1.6, not saving cache.
```
