### PR TITLE
fix: Adds restore keys to fallback

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash
       env:
         SBT_RUNNER_VERSION: ${{ inputs.sbt-runner-version }}
-        SBT_CACHE_KEY_VERSION: 1.1.6
+        SBT_CACHE_KEY_VERSION: 1.1.25
       run: |
         if [[ "$RUNNER_OS" == "Windows" ]]; then
           echo "sbt_toolpath=$RUNNER_TOOL_CACHE\\sbt\\$SBT_RUNNER_VERSION" >> "$GITHUB_OUTPUT"
@@ -60,6 +60,7 @@ runs:
       with:
         path: ${{ steps.cache-paths.outputs.sbt_diskcache }}
         key: ${{ steps.cache-paths.outputs.sbt_diskcachekey }}-${{ hashFiles('**/*.scala', '**/*.sbt', '**/*.properties') }}
+        restore-keys: ${{ steps.cache-paths.outputs.sbt_diskcachekey }}
     - name: "Download and Install sbt"
       shell: bash
       env:

--- a/example/src/test/scala/example/ATest.scala
+++ b/example/src/test/scala/example/ATest.scala
@@ -2,6 +2,7 @@ package example
 
 import munit.*
 
+//
 class ATest extends FunSuite:
   test("sum"):
     assert(1 + 1 == 2)

--- a/example/src/test/scala/example/ATest.scala
+++ b/example/src/test/scala/example/ATest.scala
@@ -2,7 +2,7 @@ package example
 
 import munit.*
 
-//
+// a
 class ATest extends FunSuite:
   test("sum"):
     assert(1 + 1 == 2)


### PR DESCRIPTION
Fixes https://github.com/sbt/setup-sbt/issues/88

## Test

https://github.com/sbt/setup-sbt/actions/runs/26426603716/job/77791402236

```bash
Run actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
  with:
    path: /home/runner/.cache/sbt
    key: Linux-sbt-diskcache-1.1.25-16da0fecfd1add19eeea45b47859973bac79871e72113a9d7ad8d06f2bdcac78
    restore-keys: Linux-sbt-diskcache-1.1.25
    enableCrossOsArchive: false
    fail-on-cache-miss: false
    lookup-only: false
    save-always: false
  env:
    JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
    JAVA_HOME: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.19-10/x64
    JAVA_HOME_17_X64: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.19-10/x64
Cache hit for restore-key: Linux-sbt-diskcache-1.1.25-60fbe20ae0caa5277703dbcdfc1673d566c1420f3c8cfc2666c2182a8afdfc2c
Received 45777 of 45777 (100.0%), 0.7 MBs/sec
```

