### PR TITLE
fix: Fixes disk cache by reducing the number of files to be hashed

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,14 +27,17 @@ runs:
           echo "sbt_toolpath=$RUNNER_TOOL_CACHE\\sbt\\$SBT_RUNNER_VERSION" >> "$GITHUB_OUTPUT"
           echo "sbt_downloadpath=$RUNNER_TEMP\\_sbt" >> "$GITHUB_OUTPUT"
           echo "sbt_diskcache=$LOCALAPPDATA\\sbt" >> "$GITHUB_OUTPUT"
+          echo "sbt_monday=$(date -d "last Monday" +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
         elif [[ "$RUNNER_OS" == "macOS" ]]; then
           echo "sbt_toolpath=$RUNNER_TOOL_CACHE/sbt/$SBT_RUNNER_VERSION" >> "$GITHUB_OUTPUT"
           echo "sbt_downloadpath=$RUNNER_TEMP/_sbt" >> "$GITHUB_OUTPUT"
           echo "sbt_diskcache=$HOME/Library/Caches/sbt" >> "$GITHUB_OUTPUT"
+          echo "sbt_monday=$(date -v-monday -v+0d +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
         else
           echo "sbt_toolpath=$RUNNER_TOOL_CACHE/sbt/$SBT_RUNNER_VERSION" >> "$GITHUB_OUTPUT"
           echo "sbt_downloadpath=$RUNNER_TEMP/_sbt" >> "$GITHUB_OUTPUT"
           echo "sbt_diskcache=$HOME/.cache/sbt" >> "$GITHUB_OUTPUT"
+          echo "sbt_monday=$(date -d "last Monday" +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
         fi
         echo "sbt_cachekey=$RUNNER_OS-sbt-$SBT_RUNNER_VERSION-$SBT_CACHE_KEY_VERSION" >> "$GITHUB_OUTPUT"
         echo "sbt_diskcachekey=$RUNNER_OS-java$JDK_VERSION-sbt-diskcache-$SBT_CACHE_KEY_VERSION" >> "$GITHUB_OUTPUT"
@@ -63,7 +66,7 @@ runs:
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ steps.cache-paths.outputs.sbt_diskcache }}
-        key: ${{ steps.cache-paths.outputs.sbt_diskcachekey }}-${{ hashFiles('**/*.scala', '**/*.sbt', '**/*.properties') }}
+        key: ${{ steps.cache-paths.outputs.sbt_diskcachekey }}-${{ steps.cache-paths.outputs.sbt_monday }}-${{ hashFiles('**/*.sbt', '**/*.properties') }}
         restore-keys: ${{ steps.cache-paths.outputs.sbt_diskcachekey }}
     - name: "Download and Install sbt"
       shell: bash


### PR DESCRIPTION
Fixes https://github.com/sbt/setup-sbt/issues/94

## Problem
There was a report of The template is not valid, potentially due to too many files being hashed for cache key.

## Solution
This attempts to fix that by removing Scala files from the hash, but including Monday's date instead.
The idea is to get caching once a week.

## Test

```bash
  with:
    path: /home/runner/.cache/sbt
    key: Linux-java17.0.19-sbt-diskcache-1.1.25-2026-05-25-15f98d083ed43771f2271b72cfc4f0cb369bba8c021691cd67c989e42dfc2f15
    restore-keys: Linux-java17.0.19-sbt-diskcache-1.1.25
```