### PR TITLE
Bump carabiner-dev/actions/ampel/verify pin from v1.2.3 to v1.2.6

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -102,7 +102,7 @@ runs:
       id: "ampel-verify"
       # Skip on Windows/macOS until go-billy path fix lands: https://github.com/go-git/go-billy/issues/194
       if: runner.os == 'Linux' && steps.cache-tool-dir2.outputs.cache-hit != 'true'
-      uses: carabiner-dev/actions/ampel/verify@2a4b2cd115ede14629b03ef7e77586d3269d4c72 # v1.2.3
+      uses: carabiner-dev/actions/ampel/verify@36a39ef667efe7112df8b1a534a4e37f35fad6fd # v1.2.6
       with:
         policy: "git+https://github.com/carabiner-dev/policies#signature/signature.json"
         subject: "${{ steps.cache-paths.outputs.sbt_downloadpath }}/sbt-${{ inputs.sbt-runner-version }}.zip"


### PR DESCRIPTION
Fixes #118.

The pinned `carabiner-dev/actions/ampel/verify@v1.2.3` (and its `install/ampel` / `install/download-and-verify` dependencies) never expand the literal `$HOME` in the default `install-dir` (`$HOME/.carabiner`) before writing it to `$GITHUB_PATH`. The `ampel` binary ends up on a bogus, cwd-relative PATH entry, and any subsequent invocation (including the `ampel version` sanity check inside `download-and-verify` itself) fails with:

```
ampel: command not found
##[error]Process completed with exit code 1.
```

This reproduces whenever the `ampel-verify` step actually runs, i.e. on an sbt-distribution cache miss (`steps.cache-tool-dir2.outputs.cache-hit != 'true'`).

This was fixed upstream in `carabiner-dev/actions` v1.2.6 (carabiner-dev/actions#97) — this PR just bumps the pin to pick that up.